### PR TITLE
Swagger generation to day-trade-api

### DIFF
--- a/day-trade-api/pom.xml
+++ b/day-trade-api/pom.xml
@@ -55,11 +55,19 @@
       <artifactId>cxf-spring-boot-starter-jaxrs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-jaxrs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+    </dependency>
 
-  	
+    
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/day-trade-api/src/main/java/org/example/ipaas/Application.java
+++ b/day-trade-api/src/main/java/org/example/ipaas/Application.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import org.apache.cxf.Bus;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.swagger.Swagger2Feature;
 import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
@@ -49,6 +50,7 @@ public class Application {
         endpoint.setServiceBeans(Arrays.<Object>asList(new OrderDeskBean()));
         endpoint.setAddress("/");
         endpoint.setProviders(Arrays.<Object>asList(new JacksonJsonProvider()));
+        endpoint.setFeatures(Arrays.asList(new Swagger2Feature()));
         return endpoint.create();
     }
 }

--- a/day-trade-api/src/main/java/org/example/ipaas/OrderDeskBean.java
+++ b/day-trade-api/src/main/java/org/example/ipaas/OrderDeskBean.java
@@ -1,5 +1,8 @@
 package org.example.ipaas;
 
+import io.swagger.annotations.Api;
+
+@Api("/apis")
 public class OrderDeskBean implements OrderDesk {
 
     @Override


### PR DESCRIPTION
This adds the generation of Swagger specification that can be accessed
at:

    http://localhost:8080/apis/swagger.json